### PR TITLE
Change stopwatch and timer font color when running and paused

### DIFF
--- a/app/src/main/java/xyz/tberghuis/floatingtimer/common/composables.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/common/composables.kt
@@ -4,13 +4,14 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.TextUnit
 
 @Composable
-fun TimeDisplay(totalSeconds: Int, fontSize: TextUnit) {
+fun TimeDisplay(totalSeconds: Int, fontSize: TextUnit, fontColor: Color) {
   val minutes = totalSeconds / 60
   val seconds = totalSeconds % 60
 
@@ -22,6 +23,7 @@ fun TimeDisplay(totalSeconds: Int, fontSize: TextUnit) {
       fontSize = fontSize,
       fontFamily = FontFamily.Default,
       style = LocalTextStyle.current.copy(fontFeatureSettings = "tnum"),
+      color = fontColor
     )
   }
 }

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/composables/SettingsTimerPreviewCard.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/composables/SettingsTimerPreviewCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -40,7 +41,11 @@ fun SettingsTimerPreviewCard(vmc: SettingsTimerPreviewVmc) {
           .width(140.dp),
         contentAlignment = Alignment.Center,
       ) {
-        CountdownViewDisplay(vmc, 0.6f, 59)
+        Box(
+          contentAlignment = Alignment.Center,
+        ) {
+          CountdownViewDisplay(vmc, 0.6f, 59, Color(0xFF888888))
+        }
       }
     }
   }

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/service/countdown/Countdown.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/service/countdown/Countdown.kt
@@ -30,6 +30,7 @@ class Countdown(
 ) : Bubble(service, bubbleSizeScaleFactor, haloColor) {
   var countdownSeconds by mutableIntStateOf(durationSeconds)
   val timerState = MutableStateFlow<TimerState>(TimerStatePaused)
+  val fontColor = MutableStateFlow(Color(0xFF888888))
   private var countDownTimer: CountDownTimer? = null
   private val vibrator = initVibrator()
 
@@ -49,10 +50,12 @@ class Countdown(
     logd("click target onclick")
     when (timerState.value) {
       is TimerStatePaused -> {
+        fontColor.value = Color(0xFF000000)
         timerState.value = TimerStateRunning
       }
 
       is TimerStateRunning -> {
+        fontColor.value = Color(0xFF888888)
         timerState.value = TimerStatePaused
       }
 

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/service/countdown/CountdownView.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/service/countdown/CountdownView.kt
@@ -11,6 +11,7 @@ import xyz.tberghuis.floatingtimer.common.TimeDisplay
 import xyz.tberghuis.floatingtimer.service.BubbleProperties
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -19,7 +20,7 @@ import androidx.compose.ui.unit.Dp
 @Composable
 fun CountdownView(countdown: Countdown) {
   val timeLeftFraction = countdown.countdownSeconds / countdown.durationSeconds.toFloat()
-  CountdownViewDisplay(countdown, timeLeftFraction, countdown.countdownSeconds)
+  CountdownViewDisplay(countdown, timeLeftFraction, countdown.countdownSeconds, countdown.fontColor.collectAsState().value)
 }
 
 // need better naming conventions
@@ -27,7 +28,8 @@ fun CountdownView(countdown: Countdown) {
 fun CountdownViewDisplay(
   bubbleProperties: BubbleProperties,
   timeLeftFraction: Float,
-  countdownSeconds: Int
+  countdownSeconds: Int,
+  fontColor: Color
 ) {
   Box(
     modifier = Modifier
@@ -37,7 +39,7 @@ fun CountdownViewDisplay(
     contentAlignment = Alignment.Center
   ) {
     CountdownProgressArc(timeLeftFraction, bubbleProperties.arcWidth, bubbleProperties.haloColor)
-    TimeDisplay(countdownSeconds, bubbleProperties.fontSize, Color(0xFF888888))
+    TimeDisplay(countdownSeconds, bubbleProperties.fontSize, fontColor)
   }
 }
 

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/service/countdown/CountdownView.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/service/countdown/CountdownView.kt
@@ -37,7 +37,7 @@ fun CountdownViewDisplay(
     contentAlignment = Alignment.Center
   ) {
     CountdownProgressArc(timeLeftFraction, bubbleProperties.arcWidth, bubbleProperties.haloColor)
-    TimeDisplay(countdownSeconds, bubbleProperties.fontSize)
+    TimeDisplay(countdownSeconds, bubbleProperties.fontSize, Color(0xFF888888))
   }
 }
 

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/service/stopwatch/StopwatchBubble.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/service/stopwatch/StopwatchBubble.kt
@@ -17,6 +17,7 @@ class Stopwatch(
 ) : Bubble(service, bubbleSizeScaleFactor, haloColor) {
   val timeElapsed = mutableIntStateOf(0)
   val isRunningStateFlow = MutableStateFlow(false)
+  val fontColor = MutableStateFlow(Color(0xFF888888))
   private var stopwatchIncrementTask: TimerTask? = null
 
   // doitwrong
@@ -25,6 +26,7 @@ class Stopwatch(
       isRunningStateFlow.collect { running ->
         when (running) {
           true -> {
+            fontColor.value = Color(0xFF000000)
             stopwatchIncrementTask = timerTask {
               timeElapsed.intValue++
             }
@@ -32,6 +34,7 @@ class Stopwatch(
           }
 
           false -> {
+            fontColor.value = Color(0xFF888888)
             stopwatchIncrementTask?.cancel()
             stopwatchIncrementTask = null
           }

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/service/stopwatch/StopwatchView.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/service/stopwatch/StopwatchView.kt
@@ -36,7 +36,7 @@ fun StopwatchView(stopwatch: Stopwatch) {
     contentAlignment = Alignment.Center
   ) {
     StopwatchBorderArc(stopwatch.isRunningStateFlow, stopwatch)
-    TimeDisplay(stopwatch.timeElapsed.intValue, stopwatch.fontSize)
+    TimeDisplay(stopwatch.timeElapsed.intValue, stopwatch.fontSize, stopwatch.fontColor.collectAsState().value)
   }
 }
 


### PR DESCRIPTION
Sets stopwatch and timer font color to gray when not running and black when running. Personally, I think the spinning arc is distracting but when it is disabled (opacity 0%) there is no other way to show when the timer is started.

Fixes #16.