### PR TITLE
Extend allowed timer sizes and fix font scaling on most sizes

### DIFF
--- a/app/src/main/java/xyz/tberghuis/floatingtimer/composables/SettingsTimerPreviewCard.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/composables/SettingsTimerPreviewCard.kt
@@ -2,7 +2,7 @@ package xyz.tberghuis.floatingtimer.composables
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import xyz.tberghuis.floatingtimer.R
@@ -24,23 +25,27 @@ import xyz.tberghuis.floatingtimer.viewmodels.SettingsTimerPreviewVmc
 fun SettingsTimerPreviewCard(vmc: SettingsTimerPreviewVmc) {
   ElevatedCard(
     modifier = Modifier
-      .height(180.dp)
+      .height(400.dp)
       .fillMaxWidth()
   ) {
-    Row(
+    Column(
       modifier = Modifier
         .padding(10.dp)
         .fillMaxSize(),
-      horizontalArrangement = Arrangement.Center,
-      verticalAlignment = Alignment.CenterVertically,
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       Text(stringResource(id = R.string.preview), fontSize = 20.sp)
-      Box(
+      Column(
         modifier = Modifier
-          .width(140.dp),
-        contentAlignment = Alignment.Center,
+          .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
       ) {
-        CountdownViewDisplay(vmc, 0.6f, 59)
+        Box(
+          contentAlignment = Alignment.Center,
+        ) {
+          CountdownViewDisplay(vmc, 0.6f, 59)
+        }
       }
     }
   }

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/constants.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/constants.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.unit.sp
 const val TRASH_SIZE_DP = 80
 
 val TIMER_SIZE_NO_SCALE = 60.dp
-val TIMER_FONT_SIZE_NO_SCALE = 16.sp
+val TIMER_FONT_SIZE_NO_SCALE = 15.5.sp
 
 const val INTENT_COMMAND = "xyz.tberghuis.floatingtimer.COMMAND"
 

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/data/PreferencesRepository.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/data/PreferencesRepository.kt
@@ -76,7 +76,7 @@ class PreferencesRepository(private val dataStore: DataStore<Preferences>) {
   }
 
   val bubbleScaleFlow: Flow<Float> = dataStore.data.map { preferences ->
-    preferences[floatPreferencesKey("bubble_scale")] ?: 0f
+    preferences[floatPreferencesKey("bubble_scale")] ?: 1f
   }
 
   suspend fun updateBubbleScale(scale: Float) {

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/screens/SizeSettingScreen.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/screens/SizeSettingScreen.kt
@@ -109,7 +109,7 @@ fun SliderScale(
       vmc.bubbleSizeScaleFactor = it
     },
     modifier = Modifier.fillMaxWidth(),
-    valueRange = 0f..1f,
+    valueRange = 0f..5f,
   )
 }
 

--- a/app/src/main/java/xyz/tberghuis/floatingtimer/service/Bubble.kt
+++ b/app/src/main/java/xyz/tberghuis/floatingtimer/service/Bubble.kt
@@ -15,9 +15,9 @@ interface BubbleProperties {
   val haloColor: Color
 
   companion object {
-    fun calcBubbleSizeDp(scaleFactor: Float) = TIMER_SIZE_NO_SCALE * (scaleFactor + 1)
-    fun calcArcWidth(scaleFactor: Float) = ARC_WIDTH_NO_SCALE * (0.9f * scaleFactor + 1)
-    fun calcFontSize(scaleFactor: Float) = TIMER_FONT_SIZE_NO_SCALE * (1.2 * scaleFactor + 1)
+    fun calcBubbleSizeDp(scaleFactor: Float) = TIMER_SIZE_NO_SCALE * (scaleFactor)
+    fun calcArcWidth(scaleFactor: Float) = ARC_WIDTH_NO_SCALE * (0.9f * scaleFactor)
+    fun calcFontSize(scaleFactor: Float) = TIMER_FONT_SIZE_NO_SCALE * (scaleFactor)
   }
 }
 


### PR DESCRIPTION
Depends on #20 (bigger timers cannot fit in the trash without it). 

It may also be a good idea to decrease the trash size since it can be a bit limiting for these large timers. And #20 fixes any issues with being able to put timers in very small trash sizes.